### PR TITLE
feat: send game results to webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# URL of the Discord Hook to send game results to.
+DISCORD_HOOK_URL=
+
 # Insights Analytics ID
 NEXT_PUBLIC_INSIGHTS_ID=
 

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,6 @@
 # URL of the Discord Hook to send game results to.
 DISCORD_HOOK_URL=
 
-# Insights Analytics ID
-NEXT_PUBLIC_INSIGHTS_ID=
-
 # Boolean, whether the app is in maintenance mode.
 NEXT_PUBLIC_MAINTENANCE=
 

--- a/interfaces/HookData.ts
+++ b/interfaces/HookData.ts
@@ -1,0 +1,22 @@
+/**
+ * Data to send to the /sendGame API route.
+ */
+interface HookData {
+	/**
+	 * The correct RGB values of this game.
+	 */
+	correct: [number, number, number];
+	/**
+	 * The guesses made by the user.
+	 */
+	guesses: [number, number, number][];
+	/**
+	 * The day of the game.
+	 */
+	day: number;
+	/**
+	 * The name of the color.
+	 */
+	name: string;
+}
+export default HookData;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rgbdle",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"author": "hickatheworld",
 	"scripts": {
 		"dev": "next dev",

--- a/pages/api/sendGame.ts
+++ b/pages/api/sendGame.ts
@@ -20,7 +20,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 		**Guesses:**\n ${guessString}
 		**Solution:** ${correct[0]}, ${correct[1]}, ${correct[2]}
 	`;
-		const didGuess = guesses[guesses.length - 1] === correct;
+		const lastGuess = guesses[guesses.length - 1];
+		const didGuess = lastGuess[0] === correct[0] && lastGuess[1] === correct[1] && lastGuess[2] === correct[2];
 		const embed = {
 			title: 'New game submitted!',
 			description: body,

--- a/pages/api/sendGame.ts
+++ b/pages/api/sendGame.ts
@@ -1,0 +1,51 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import HookData from '../../interfaces/HookData';
+
+
+// This sends the results of a game to a Discord Webhook.
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+	try {
+		const { correct, guesses, day, name } = req.body as HookData;
+		let guessString = '';
+		for (const row of guesses) {
+			guessString += '\n';
+			for (const j in row) {
+				const c = row[j];
+				guessString += c === correct[j] ? '🟩' : c < correct[j] ? '🟪' : '🟧';
+			}
+			guessString += ` ${row[0]}, ${row[1]}, ${row[2]}`;
+		}
+		const body = `
+		**Color:** ${name}
+		**Guesses:**\n ${guessString}
+		**Solution:** ${correct[0]}, ${correct[1]}, ${correct[2]}
+	`;
+		const didGuess = guesses.at(-1) === correct;
+		const embed = {
+			title: 'New game submitted!',
+			description: body,
+			color: 0x2f3136,
+			thumbnail: {
+				url: 'https://rgbdle.hicka.world/android-chrome-512x512.png'
+			},
+			footer: {
+				text: `RGBdle ${day} ${didGuess ? guesses.length : 'X'}/10`
+			},
+			timestamp: new Date().toISOString()
+		}
+		await fetch(process.env.DISCORD_HOOK_URL!, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify({
+				embeds: [embed]
+			})
+		});
+		res.status(200).end();
+	} catch (e: any) {
+		console.error(e);
+		res.status(500).send(e.message || 'Something unknown went wrong.');
+	}
+};
+export default handler;

--- a/pages/api/sendGame.ts
+++ b/pages/api/sendGame.ts
@@ -20,7 +20,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 		**Guesses:**\n ${guessString}
 		**Solution:** ${correct[0]}, ${correct[1]}, ${correct[2]}
 	`;
-		const didGuess = guesses.at(-1) === correct;
+		const didGuess = guesses[guesses.length - 1] === correct;
 		const embed = {
 			title: 'New game submitted!',
 			description: body,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -110,35 +110,34 @@ const Home = ({ colors }: { colors: Record<string, ColorInfo> }) => {
 			guesses: [...guesses, guess]
 		}));
 		if (correct === 3)
-			endGame(guesses.length + 1);
+			endGame(guesses.length + 1, [...guesses, guess]);
 		else if (guesses.length + 1 === 10)
-			endGame(-1);
+			endGame(-1, [...guesses, guess]);
 	};
 
-	const endGame = async (attemptsCount: number): Promise<void> => {
+	const endGame = async (attemptsCount: number, guesses: [number, number, number][]): Promise<void> => {
 		setEnded(true);
 		attempts.push(attemptsCount);
 		localStorage.setItem('RGBDLE_ATTEMPTS', JSON.stringify(attempts));
 		setAttempts(attempts);
 		// Sending game results to webhook.
-		try {
-			await fetch('/api/sendGame', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify({
-					correct: color.rgb,
-					day: color.day,
-					guesses,
-					name: color.name
-				})
-			});
-			console.log('Game results sent to webhook.');
-		} catch (e: any) {
+		fetch('/api/sendGame', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify({
+				correct: color.rgb,
+				day: color.day,
+				guesses,
+				name: color.name
+			})
+		}).then(() => {
+			console.log('Resuls sent to webhook.');
+		}).catch(e => {
 			console.error('Failed to send game results. Error:');
 			console.error(e);
-		}
+		});
 		display('results');
 	}
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -222,15 +222,6 @@ const Home = ({ colors }: { colors: Record<string, ColorInfo> }) => {
 
 	return (
 		<div className='relative h-full overflow-hidden'>
-			{/* Analytics */}
-			{/* Note: Insights analytics don't collect any user's data. */}
-			<Script
-				src='https://getinsights.io/js/insights.js'
-				onLoad={() => {
-					insights.init(process.env.NEXT_PUBLIC_INSIGHTS_ID);
-					insights.trackPages();
-				}}
-			/>
 			{head}
 			{
 				isLoading ?

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -48,7 +48,6 @@ const Home = ({ colors }: { colors: Record<string, ColorInfo> }) => {
 
 	useEffect(() => {
 		/* Checking the save of today's game. */
-
 		const save = parse(localStorage.getItem('RGBDLE_SAVE') || '{}') as any;
 		// It can be anything, the user may have messed up with localStorage. And `unknown` is a bullshit type.
 		if (
@@ -88,13 +87,11 @@ const Home = ({ colors }: { colors: Record<string, ColorInfo> }) => {
 			}
 		}
 
-
 		/* Keyboard shortcut to close popup. */
 		window.addEventListener('keydown', (e) => {
 			if (e.key === 'Escape')
 				display('none');
 		});
-
 	}, []);
 
 	const submitGuess = (guess: [number, number, number]): void => {
@@ -118,11 +115,30 @@ const Home = ({ colors }: { colors: Record<string, ColorInfo> }) => {
 			endGame(-1);
 	};
 
-	const endGame = (attemptsCount: number): void => {
+	const endGame = async (attemptsCount: number): Promise<void> => {
 		setEnded(true);
 		attempts.push(attemptsCount);
 		localStorage.setItem('RGBDLE_ATTEMPTS', JSON.stringify(attempts));
 		setAttempts(attempts);
+		// Sending game results to webhook.
+		try {
+			await fetch('/api/sendGame', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({
+					correct: color.rgb,
+					day: color.day,
+					guesses,
+					name: color.name
+				})
+			});
+			console.log('Game results sent to webhook.');
+		} catch (e: any) {
+			console.error('Failed to send game results. Error:');
+			console.error(e);
+		}
 		display('results');
 	}
 


### PR DESCRIPTION
# Changes
With this PR, all games that end are sent to a Discord Webhook. This replaces the analytics service.  
**No user's data is sent anywhere, only the guesses made by the user are sent, *completely anonymously.* 
Also, Discord does not know your IP address from this request. The request to Discord is made from Vercel servers.**